### PR TITLE
Explore new project features

### DIFF
--- a/models/database/models.go
+++ b/models/database/models.go
@@ -33,7 +33,8 @@ func init() {
 	db.DB().SetMaxOpenConns(100)
 
 	// 自动迁移统计相关表
-	db.AutoMigrate(&VisitRecord{})
+    db.AutoMigrate(&VisitRecord{})
+    db.AutoMigrate(&ContentStats{})
 }
 
 func GetDB() *gorm.DB {

--- a/models/response/stats.go
+++ b/models/response/stats.go
@@ -76,3 +76,34 @@ type LocationStat struct {
 	City    string `json:"city"`
 	Count   int    `json:"count"`
 }
+
+// 热门页面统计
+type PageStat struct {
+    Page  string `json:"page"`
+    Count int    `json:"count"`
+}
+
+// 趋势点（按天聚合）
+type TrendPoint struct {
+    Date            string `json:"date"`
+    Visits          int    `json:"visits"`
+    UniqueVisitors  int    `json:"unique_visitors"`
+    UniqueSessions  int    `json:"unique_sessions"`
+}
+
+type TrendResult struct {
+    Points []TrendPoint `json:"points"`
+}
+
+// 日统计（与趋势结构一致）
+type DailyResult struct {
+    Points []TrendPoint `json:"points"`
+}
+
+// 内容统计响应
+type ContentStatsResponse struct {
+    TotalArticles   int    `json:"total_articles"`
+    TotalTags       int    `json:"total_tags"`
+    TotalCategories int    `json:"total_categories"`
+    LastUpdate      string `json:"last_update"`
+}

--- a/routers/api/stats.go
+++ b/routers/api/stats.go
@@ -134,3 +134,129 @@ func GetUserBehavior(c *gin.Context) {
 		"data": behavior,
 	})
 }
+
+// GetTopPages 获取热门页面
+// @Summary 获取热门页面
+// @Description 按访问量降序返回热门页面列表
+// @Tags 统计
+// @Accept json
+// @Produce json
+// @Param limit query int false "返回数量" default(10)
+// @Param start_date query string false "开始日期(YYYY-MM-DD)"
+// @Param end_date query string false "结束日期(YYYY-MM-DD)"
+// @Param language query string false "语言过滤"
+// @Success 200 {object} map[string]interface{} "成功"
+// @Router /stats/pages [get]
+func GetTopPages(c *gin.Context) {
+    limit := 10
+    if v := c.Query("limit"); v != "" {
+        if n, err := strconv.Atoi(v); err == nil {
+            limit = n
+        }
+    }
+    start := c.Query("start_date")
+    end := c.Query("end_date")
+    language := c.Query("language")
+
+    stats, err := database.GetTopPages(limit, start, end, language)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"code": e.ERROR, "msg": "Failed to get pages", "data": gin.H{}})
+        return
+    }
+    c.JSON(http.StatusOK, gin.H{"code": e.SUCCESS, "msg": e.GetMsg(e.SUCCESS), "data": gin.H{"pages": stats}})
+}
+
+// GetTrend 获取访问趋势
+// @Summary 获取访问趋势
+// @Description 返回最近N天的访问量、独立访客、独立会话趋势
+// @Tags 统计
+// @Accept json
+// @Produce json
+// @Param days query int false "天数" default(30)
+// @Param language query string false "语言过滤"
+// @Success 200 {object} map[string]interface{} "成功"
+// @Router /stats/trend [get]
+func GetTrend(c *gin.Context) {
+    days := 30
+    if v := c.Query("days"); v != "" {
+        if n, err := strconv.Atoi(v); err == nil {
+            days = n
+        }
+    }
+    language := c.Query("language")
+    res, err := database.GetTrend(days, language)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"code": e.ERROR, "msg": "Failed to get trend", "data": gin.H{}})
+        return
+    }
+    c.JSON(http.StatusOK, gin.H{"code": e.SUCCESS, "msg": e.GetMsg(e.SUCCESS), "data": res})
+}
+
+// GetDaily 获取日统计（与趋势同结构，主要用于固定时间窗口或分页）
+// @Summary 获取日统计
+// @Description 返回按天聚合的访问/访客/会话数据
+// @Tags 统计
+// @Accept json
+// @Produce json
+// @Param days query int false "天数" default(30)
+// @Param language query string false "语言过滤"
+// @Success 200 {object} map[string]interface{} "成功"
+// @Router /stats/daily [get]
+func GetDaily(c *gin.Context) {
+    days := 30
+    if v := c.Query("days"); v != "" {
+        if n, err := strconv.Atoi(v); err == nil {
+            days = n
+        }
+    }
+    language := c.Query("language")
+    res, err := database.GetTrend(days, language)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"code": e.ERROR, "msg": "Failed to get daily", "data": gin.H{}})
+        return
+    }
+    c.JSON(http.StatusOK, gin.H{"code": e.SUCCESS, "msg": e.GetMsg(e.SUCCESS), "data": gin.H{"points": res.Points}})
+}
+
+// GetContentStats 获取内容统计
+// @Summary 获取内容统计
+// @Description 返回文章/标签/分类等汇总
+// @Tags 统计
+// @Accept json
+// @Produce json
+// @Success 200 {object} map[string]interface{} "成功"
+// @Router /stats/content [get]
+func GetContentStats(c *gin.Context) {
+    res, err := database.GetContentStats()
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"code": e.ERROR, "msg": "Failed to get content stats", "data": gin.H{}})
+        return
+    }
+    c.JSON(http.StatusOK, gin.H{"code": e.SUCCESS, "msg": e.GetMsg(e.SUCCESS), "data": res})
+}
+
+// UpdateContentStats 更新内容统计
+// @Summary 更新内容统计
+// @Description 更新文章/标签/分类数量（追加一条快照）
+// @Tags 统计
+// @Accept json
+// @Produce json
+// @Param body body struct{Articles int `json:"articles"`; Tags int `json:"tags"`; Categories int `json:"categories"`} true "内容统计"
+// @Success 200 {object} map[string]interface{} "成功"
+// @Router /stats/content [post]
+func UpdateContentStats(c *gin.Context) {
+    var payload struct {
+        Articles   int `json:"articles"`
+        Tags       int `json:"tags"`
+        Categories int `json:"categories"`
+    }
+    if err := c.ShouldBindJSON(&payload); err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{"code": 400, "msg": "Invalid JSON data", "data": gin.H{}})
+        return
+    }
+    if err := database.UpdateContentStats(payload.Articles, payload.Tags, payload.Categories); err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"code": e.ERROR, "msg": "Failed to update content stats", "data": gin.H{}})
+        return
+    }
+    c.JSON(http.StatusOK, gin.H{"code": e.SUCCESS, "msg": e.GetMsg(e.SUCCESS), "data": gin.H{"updated": true}})
+}

--- a/routers/router.go
+++ b/routers/router.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
+    "strconv"
 
 	ginswagger "github.com/swaggo/gin-swagger"
 	swaggerFiles "github.com/swaggo/gin-swagger/swaggerFiles"
@@ -54,6 +55,14 @@ func InitRouter() *gin.Engine {
 		stats.GET("/visits", api.GetVisitStats)
 		// 获取用户行为分析
 		stats.GET("/behavior", api.GetUserBehavior)
+        // 获取热门页面
+        stats.GET("/pages", api.GetTopPages)
+        // 获取访问趋势 & 日统计
+        stats.GET("/trend", api.GetTrend)
+        stats.GET("/daily", api.GetDaily)
+        // 内容统计读写
+        stats.GET("/content", api.GetContentStats)
+        stats.POST("/content", api.UpdateContentStats)
 		// Dashboard API
 		stats.GET("/records", api.GetVisitRecords)
 		stats.GET("/overview", api.GetVisitOverview)


### PR DESCRIPTION
Implement new statistics APIs for top pages, visit trends, daily stats, and content statistics to fulfill high-priority feature requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e6c778c-55e7-4acc-a610-e32405549f99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9e6c778c-55e7-4acc-a610-e32405549f99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce analytics endpoints for top pages, trends/daily metrics, and content statistics with supporting DB models and response types.
> 
> - **Backend**:
>   - **Database Models/Migration**:
>     - Add `ContentStats` model and auto-migrate (`models/database/models.go`).
>   - **Stats Queries**:
>     - Implement `GetTopPages`, `GetTrend`, `GetContentStats`, `UpdateContentStats`, and `withLanguage` in `models/database/stats.go`.
>   - **Response Types**:
>     - Add `PageStat`, `TrendPoint`, `TrendResult`, `DailyResult`, `ContentStatsResponse` in `models/response/stats.go`.
> - **API**:
>   - New endpoints in `routers/api/stats.go`:
>     - `GET /stats/pages` (top pages), `GET /stats/trend`, `GET /stats/daily`.
>     - `GET /stats/content`, `POST /stats/content` for content stats read/write.
> - **Routing**:
>   - Wire endpoints in `routers/router.go`; add imports and route registrations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22d0b06672d886ff6fb8562966052e898574df20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->